### PR TITLE
proposed keybindings based on ctrl+shift+space prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva Power Tools
 
 ## [Unreleased]
 
+- Fix: [Propose a set of keybindings with the ctrl+shift+space prefix](https://github.com/BetterThanTomorrow/calva-power-tools/issues/15)
+
 ## [v0.0.2] - 2025-04-30
 
 - Improved README to talk about Clay

--- a/package.json
+++ b/package.json
@@ -91,43 +91,35 @@
     ],
     "keybindings": [
       {
-        "key": "ctrl+alt+a f",
+        "key": "ctrl+shift+space , .",
         "command": "clay.makeFile"
       },
       {
-        "key": "ctrl+alt+a q f",
+        "key": "ctrl+shift+space , q .",
         "command": "clay.makeFileQuarto"
       },
       {
-        "key": "ctrl+alt+a r f",
+        "key": "ctrl+shift+space , r .",
         "command": "clay.makeFileRevealJs"
       },
       {
-        "key": "ctrl+alt+a c",
+        "key": "ctrl+shift+space , c",
         "command": "clay.makeCurrentForm"
       },
       {
-        "key": "ctrl+alt+a q c",
+        "key": "ctrl+shift+space , q c",
         "command": "clay.makeCurrentFormQuarto"
       },
       {
-        "key": "ctrl+alt+a a",
+        "key": "ctrl+shift+space , ,",
         "command": "clay.makeTopLevelForm"
       },
       {
-        "key": "ctrl+alt+a ctrl+alt+a",
-        "command": "clay.makeTopLevelForm"
-      },
-      {
-        "key": "ctrl+alt+a q a",
+        "key": "ctrl+shift+space , q ,",
         "command": "clay.makeTopLevelFormQuarto"
       },
       {
-        "key": "ctrl+alt+a b",
-        "command": "clay.browse"
-      },
-      {
-        "key": "ctrl+alt+a w",
+        "key": "ctrl+shift+space , w",
         "command": "clay.watch"
       }
     ]

--- a/package.json
+++ b/package.json
@@ -91,35 +91,39 @@
     ],
     "keybindings": [
       {
-        "key": "ctrl+shift+space , .",
+        "key": "ctrl+shift+space a f",
         "command": "clay.makeFile"
       },
       {
-        "key": "ctrl+shift+space , q .",
+        "key": "ctrl+shift+space a q f",
         "command": "clay.makeFileQuarto"
       },
       {
-        "key": "ctrl+shift+space , r .",
+        "key": "ctrl+shift+space a r f",
         "command": "clay.makeFileRevealJs"
       },
       {
-        "key": "ctrl+shift+space , c",
+        "key": "ctrl+shift+space a c",
         "command": "clay.makeCurrentForm"
       },
       {
-        "key": "ctrl+shift+space , q c",
+        "key": "ctrl+shift+space a q c",
         "command": "clay.makeCurrentFormQuarto"
       },
       {
-        "key": "ctrl+shift+space , ,",
+        "key": "ctrl+shift+space a a",
         "command": "clay.makeTopLevelForm"
       },
       {
-        "key": "ctrl+shift+space , q ,",
+        "key": "ctrl+shift+space a q a",
         "command": "clay.makeTopLevelFormQuarto"
       },
       {
-        "key": "ctrl+shift+space , w",
+        "key": "ctrl+shift+space a b",
+        "command": "clay.watch"
+      },
+      {
+        "key": "ctrl+shift+space a w",
         "command": "clay.watch"
       }
     ]

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
       },
       {
         "key": "ctrl+shift+space a b",
-        "command": "clay.watch"
+        "command": "clay.browse"
       },
       {
         "key": "ctrl+shift+space a w",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,10 @@
         "command": "clay.makeCurrentFormQuarto"
       },
       {
+        "key": "ctrl+shift+space ctrl+shift+a",
+        "command": "clay.makeTopLevelForm"
+      },
+      {
         "key": "ctrl+shift+space a a",
         "command": "clay.makeTopLevelForm"
       },


### PR DESCRIPTION
## Description

* The key bindings prefix is now `ctrl+shift+space`.
* The Clay prefix is `,` following the general prefix.
* In the following Clay key pressed, `,` means top-level form, and `.` means file.
* "Clay browse" does not have a key binding anymore.
* For now, Clay does not have any additional quick bindings anymore, only those following the general prefix.

Discussion: https://github.com/BetterThanTomorrow/calva-power-tools/discussions/4#discussioncomment-13001334

- Fixes #15 

## Checklist

- [x] I have read [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md)
- [x] There is an [issue](../issues) with a clear problem statement related to this change
- [x] I have added an entry to the **`[Unreleased]`** section of [CHANGELOG.md](../blob/master/CHANGELOG.md) linking to the issue(s) addressed
- [x] README/docs updated (or not relevant)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
