### PR TITLE
Added when clauses to keybindings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva Power Tools
 
 ## [Unreleased]
 
+- Fix: [Default keybindings should have when clauses limiting their reach](https://github.com/BetterThanTomorrow/calva-power-tools/issues/14)
+
 ## [v0.0.3] - 2025-05-01
 
 - Fix: [Propose a set of keybindings with the ctrl+shift+space prefix](https://github.com/BetterThanTomorrow/calva-power-tools/issues/15)

--- a/package.json
+++ b/package.json
@@ -93,52 +93,52 @@
       {
         "key": "ctrl+shift+space a f",
         "command": "clay.makeFile",
-        "when": "calva:keybindingsEnabled && editorTextFocus && editorLangId == 'clojure'"
+        "when": "editorTextFocus && editorLangId == 'clojure'"
       },
       {
         "key": "ctrl+shift+space a q f",
         "command": "clay.makeFileQuarto",
-        "when": "calva:keybindingsEnabled && editorTextFocus && editorLangId == 'clojure'"
+        "when": "editorTextFocus && editorLangId == 'clojure'"
       },
       {
         "key": "ctrl+shift+space a r f",
         "command": "clay.makeFileRevealJs",
-        "when": "calva:keybindingsEnabled && editorTextFocus && editorLangId == 'clojure'"
+        "when": "editorTextFocus && editorLangId == 'clojure'"
       },
       {
         "key": "ctrl+shift+space a c",
         "command": "clay.makeCurrentForm",
-        "when": "calva:keybindingsEnabled && editorTextFocus && editorLangId == 'clojure'"
+        "when": "editorTextFocus && editorLangId == 'clojure'"
       },
       {
         "key": "ctrl+shift+space a q c",
         "command": "clay.makeCurrentFormQuarto",
-        "when": "calva:keybindingsEnabled && editorTextFocus && editorLangId == 'clojure'"
+        "when": "editorTextFocus && editorLangId == 'clojure'"
       },
       {
         "key": "ctrl+shift+space ctrl+shift+a",
         "command": "clay.makeTopLevelForm",
-        "when": "calva:keybindingsEnabled && editorTextFocus && editorLangId == 'clojure'"
+        "when": "editorTextFocus && editorLangId == 'clojure'"
       },
       {
         "key": "ctrl+shift+space a a",
         "command": "clay.makeTopLevelForm",
-        "when": "calva:keybindingsEnabled && editorTextFocus && editorLangId == 'clojure'"
+        "when": "editorTextFocus && editorLangId == 'clojure'"
       },
       {
         "key": "ctrl+shift+space a q a",
         "command": "clay.makeTopLevelFormQuarto",
-        "when": "calva:keybindingsEnabled && editorTextFocus && editorLangId == 'clojure'"
+        "when": "editorTextFocus && editorLangId == 'clojure'"
       },
       {
         "key": "ctrl+shift+space a b",
         "command": "clay.browse",
-        "when": "calva:keybindingsEnabled && editorTextFocus && editorLangId == 'clojure'"
+        "when": "editorTextFocus && editorLangId == 'clojure'"
       },
       {
         "key": "ctrl+shift+space a w",
         "command": "clay.watch",
-        "when": "calva:keybindingsEnabled && editorTextFocus && editorLangId == 'clojure'"
+        "when": "editorTextFocus && editorLangId == 'clojure'"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -92,43 +92,53 @@
     "keybindings": [
       {
         "key": "ctrl+shift+space a f",
-        "command": "clay.makeFile"
+        "command": "clay.makeFile",
+        "when": "calva:keybindingsEnabled && editorTextFocus && editorLangId == 'clojure'"
       },
       {
         "key": "ctrl+shift+space a q f",
-        "command": "clay.makeFileQuarto"
+        "command": "clay.makeFileQuarto",
+        "when": "calva:keybindingsEnabled && editorTextFocus && editorLangId == 'clojure'"
       },
       {
         "key": "ctrl+shift+space a r f",
-        "command": "clay.makeFileRevealJs"
+        "command": "clay.makeFileRevealJs",
+        "when": "calva:keybindingsEnabled && editorTextFocus && editorLangId == 'clojure'"
       },
       {
         "key": "ctrl+shift+space a c",
-        "command": "clay.makeCurrentForm"
+        "command": "clay.makeCurrentForm",
+        "when": "calva:keybindingsEnabled && editorTextFocus && editorLangId == 'clojure'"
       },
       {
         "key": "ctrl+shift+space a q c",
-        "command": "clay.makeCurrentFormQuarto"
+        "command": "clay.makeCurrentFormQuarto",
+        "when": "calva:keybindingsEnabled && editorTextFocus && editorLangId == 'clojure'"
       },
       {
         "key": "ctrl+shift+space ctrl+shift+a",
-        "command": "clay.makeTopLevelForm"
+        "command": "clay.makeTopLevelForm",
+        "when": "calva:keybindingsEnabled && editorTextFocus && editorLangId == 'clojure'"
       },
       {
         "key": "ctrl+shift+space a a",
-        "command": "clay.makeTopLevelForm"
+        "command": "clay.makeTopLevelForm",
+        "when": "calva:keybindingsEnabled && editorTextFocus && editorLangId == 'clojure'"
       },
       {
         "key": "ctrl+shift+space a q a",
-        "command": "clay.makeTopLevelFormQuarto"
+        "command": "clay.makeTopLevelFormQuarto",
+        "when": "calva:keybindingsEnabled && editorTextFocus && editorLangId == 'clojure'"
       },
       {
         "key": "ctrl+shift+space a b",
-        "command": "clay.browse"
+        "command": "clay.browse",
+        "when": "calva:keybindingsEnabled && editorTextFocus && editorLangId == 'clojure'"
       },
       {
         "key": "ctrl+shift+space a w",
-        "command": "clay.watch"
+        "command": "clay.watch",
+        "when": "calva:keybindingsEnabled && editorTextFocus && editorLangId == 'clojure'"
       }
     ]
   },


### PR DESCRIPTION
## Description

Added `when` clauses to keybindings. All Clay commands should have the same scope as the usual "Calva Evaluate Top Level Form" command.

- Fixes #14 

## Checklist

- [x] I have read [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md)
- [x] There is an [issue](../issues) with a clear problem statement related to this change
- [x] I have added an entry to the **`[Unreleased]`** section of [CHANGELOG.md](../blob/master/CHANGELOG.md) linking to the issue(s) addressed
- [x] README/docs updated (or not relevant)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
