### PR TITLE
18 add load clay deps command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva Power Tools
 
 ## [Unreleased]
 
+- [Add command for loading Clay dependency](https://github.com/BetterThanTomorrow/calva-power-tools/issues/18)
+
 ## [v0.0.5] - 2025-05-04
 
 - [Add tools-deps tool, with add-libs commands](https://github.com/BetterThanTomorrow/calva-power-tools/issues/7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ Changes to Calva Power Tools
 
 ## [Unreleased]
 
-- [Add command for loading Clay dependency](https://github.com/BetterThanTomorrow/calva-power-tools/issues/18)
-
 ## [v0.0.5] - 2025-05-04
 
 - [Add tools-deps tool, with add-libs commands](https://github.com/BetterThanTomorrow/calva-power-tools/issues/7)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Calva Power Tools
 
-A VSCode extension, and [Calva](https://calva.io) companion, for Clojure and ClojureScript development that adds commands for popular Clojure libraries and tools.
+A VSCode extension, and [Calva](https://calva.io) companion, for Clojure and ClojureScript development that adds commands for popular Clojure libraries and tools. Including commands for dynamically loading the tool dependencies.
 
 ## Supported Tools
+
+A hopefully a growing list! Calva Power Tools aims to be very [contributor](#contributing) friendly!
 
 * [tools-deps](https://clojure.org/guides/deps_and_cli) for dependency management.
 * [Clay](https://scicloj.github.io/clay/) for literate programming and data visuallization.
@@ -35,12 +37,10 @@ A set of commands leveraging Clojure 1.12 `add-libs`:
 Explore the Clay commands from the VS Code command palette by fuzzy searching “Clay”.
 Also check this intoduction out: https://www.youtube.com/watch?v=B1yPkpyiEEs
 
+If your project doesn't have a Clay dependency set up, you can still use Clay by starting your session with the command:
+* **Clay: Load Clay Dependency**
+
 **Tool Key**: <kbd>a</kbd>
-
-## Rationale
-
-Users access IDE functionality via commands and the command palette, but tools and libraries cannot add these to VSCode except via an extension.
-Calva Power Tools is a contributor friendly way for library and tool authors to provide commands in VSCode without making a separate extension.
 
 ## Contributing
 

--- a/example-projects/clay-project/.vscode/settings.json
+++ b/example-projects/clay-project/.vscode/settings.json
@@ -9,14 +9,14 @@
   //// https://calva.io/connect-sequences/
   "calva.replConnectSequences": [
     {
-      "name": "Mini Clojure Project",
+      "name": "Mini Clay Project",
       "autoSelectForConnect": true,
       "autoSelectForJackIn": true,
       "projectRootPath": ["."],
       "cljsType": "none",
       "projectType": "deps.edn",
       "menuSelections": {
-        "cljAliases": ["test"]
+        "cljAliases": ["test", "clay"]
       }
     }
   ],

--- a/example-projects/clay-project/deps.edn
+++ b/example-projects/clay-project/deps.edn
@@ -1,4 +1,4 @@
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.12.0"}
-        org.scicloj/clay {:mvn/version "2-beta40"}}
- :aliases {:test {:extra-paths ["test"]}}}
+ :deps {org.clojure/clojure {:mvn/version "1.12.0"}}
+ :aliases {:test {:extra-paths ["test"]}
+           :clay {:extra-deps {org.scicloj/clay {:mvn/version "2-beta42"}}}}}

--- a/example-projects/clay-project/deps.edn
+++ b/example-projects/clay-project/deps.edn
@@ -1,4 +1,4 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}}
  :aliases {:test {:extra-paths ["test"]}
-           :clay {:extra-deps {org.scicloj/clay {:mvn/version "2-beta42"}}}}}
+           :clay {:extra-deps {#_#_org.scicloj/clay {:mvn/version "2-beta42"}}}}}

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
   "contributes": {
     "configuration": [{
       "type": "object",
-      "title": "Clay",
+      "title": "Calva Power Tools",
       "properties": {
-        "calva-power-tools.clay.version": {
+        "calva-power-tools.clay.dependencyVersion": {
           "type": "string",
           "default": "2-beta42"
         }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,16 @@
   ],
   "main": "out/extension.js",
   "contributes": {
+    "configuration": [{
+      "type": "object",
+      "title": "Clay",
+      "properties": {
+        "calva-power-tools.clay.version": {
+          "type": "string",
+          "default": "2-beta42"
+        }
+      }
+    }],
     "commands": [
       {
         "command": "clay.makeFile",
@@ -87,6 +97,11 @@
         "command": "clay.watch",
         "category": "Clay",
         "title": "Watch"
+      },
+      {
+        "command": "clay.loadClayDependency",
+        "category": "Clay",
+        "title": "Load Clay Dependency"
       },
       {
         "command": "deps.loadSelectedDependencies",
@@ -154,6 +169,11 @@
         "key": "ctrl+shift+space a w",
         "command": "clay.watch",
         "when": "editorTextFocus && editorLangId == 'clojure'"
+      },
+      {
+        "key": "ctrl+shift+space a d",
+        "command": "clay.loadClayDependency",
+        "when": "calva:activated"
       },
       {
         "key": "ctrl+shift+space d d",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
       {
         "command": "clay.loadClayDependency",
         "category": "Clay",
-        "title": "Load Clay Dependency"
+        "title": "Load Clay Dependency",
+        "enablement": "false"
       },
       {
         "command": "deps.loadSelectedDependencies",
@@ -163,7 +164,7 @@
       {
         "key": "ctrl+shift+space a d",
         "command": "clay.loadClayDependency",
-        "when": "calva:activated"
+        "when": "false && calva:activated"
       },
       {
         "key": "ctrl+shift+space d d",

--- a/package.json
+++ b/package.json
@@ -42,16 +42,6 @@
   ],
   "main": "out/extension.js",
   "contributes": {
-    "configuration": [{
-      "type": "object",
-      "title": "Calva Power Tools",
-      "properties": {
-        "calva-power-tools.clay.dependencyVersion": {
-          "type": "string",
-          "default": "2-beta42"
-        }
-      }
-    }],
     "commands": [
       {
         "command": "clay.makeFile",

--- a/src/calva_power_tools/calva.cljs
+++ b/src/calva_power_tools/calva.cljs
@@ -1,4 +1,4 @@
-(ns calva-power-tools.extension.calva
+(ns calva-power-tools.calva
   (:require
    ["vscode" :as vscode]
    [calva-power-tools.extension.db :as db]
@@ -34,3 +34,4 @@
                                 (fn []
                                   (execute-calva-command! "calva.runCustomREPLCommand"
                                                           (clj->js snippet)))))
+

--- a/src/calva_power_tools/tool/clay.cljs
+++ b/src/calva_power_tools/tool/clay.cljs
@@ -32,6 +32,4 @@
   (lc-helpers/register-command!
    db/!app-db "clay.loadClayDependency"
    (fn []
-     (let [snippet (util/tool-dependency-load-snippet {:deps/mvn-name "org.scicloj/clay"})]
-       (calva/execute-calva-command! "calva.runCustomREPLCommand"
-                                     (clj->js snippet))))))
+     (util/load-dependency {:deps/mvn-name "org.scicloj/clay"}))))

--- a/src/calva_power_tools/tool/clay.cljs
+++ b/src/calva_power_tools/tool/clay.cljs
@@ -32,7 +32,6 @@
   (lc-helpers/register-command!
    db/!app-db "clay.loadClayDependency"
    (fn []
-     (let [snippet (util/tool-dependency-load-version-snippet {:config/path "clay.dependencyVersion"
-                                                               :deps/mvn-name "org.scicloj/clay"})]
+     (let [snippet (util/tool-dependency-load-snippet {:deps/mvn-name "org.scicloj/clay"})]
        (calva/execute-calva-command! "calva.runCustomREPLCommand"
                                      (clj->js snippet))))))

--- a/src/calva_power_tools/tool/clay.cljs
+++ b/src/calva_power_tools/tool/clay.cljs
@@ -1,6 +1,9 @@
 (ns calva-power-tools.tool.clay
   (:require
-   [calva-power-tools.extension.calva :as calva]
+   [calva-power-tools.calva :as calva]
+   [calva-power-tools.extension.db :as db]
+   [calva-power-tools.extension.life-cycle-helpers :as lc-helpers]
+   [calva-power-tools.util :as util]
    [clojure.string :as str]))
 
 (defn make-snippet
@@ -25,8 +28,11 @@
   (calva/register-snippet! "clay.makeTopLevelFormQuarto" (make-snippet "make-form-quarto-html!" top-level-form file options))
   (calva/register-snippet! "clay.browse" (make-snippet "browse!"))
   (calva/register-snippet! "clay.watch" (make-snippet "watch!" options))
-  (calva/register-snippet! "clay.loadClayDependency"
-                           {:snippet (str '((requiring-resolve 'clojure.repl.deps/add-libs)
-                                            '{org.scicloj/clay {:mvn/version "2-beta40"}}))
-                            :ns "user"
-                            :repl "clj"}))
+
+  (lc-helpers/register-command!
+   db/!app-db "clay.loadClayDependency"
+   (fn []
+     (let [snippet (util/tool-dependency-load-version-snippet {:config/path "clay.dependencyVersion"
+                                                               :deps/mvn-name "org.scicloj/clay"})]
+       (calva/execute-calva-command! "calva.runCustomREPLCommand"
+                                     (clj->js snippet))))))

--- a/src/calva_power_tools/tool/clay.cljs
+++ b/src/calva_power_tools/tool/clay.cljs
@@ -24,4 +24,9 @@
   (calva/register-snippet! "clay.makeTopLevelForm" (make-snippet "make-form-html!" top-level-form file options))
   (calva/register-snippet! "clay.makeTopLevelFormQuarto" (make-snippet "make-form-quarto-html!" top-level-form file options))
   (calva/register-snippet! "clay.browse" (make-snippet "browse!"))
-  (calva/register-snippet! "clay.watch" (make-snippet "watch!" options)))
+  (calva/register-snippet! "clay.watch" (make-snippet "watch!" options))
+  (calva/register-snippet! "clay.loadClayDependency"
+                           {:snippet (str '((requiring-resolve 'clojure.repl.deps/add-libs)
+                                            '{org.scicloj/clay {:mvn/version "2-beta40"}}))
+                            :ns "user"
+                            :repl "clj"}))

--- a/src/calva_power_tools/tool/tools_deps.cljs
+++ b/src/calva_power_tools/tool/tools_deps.cljs
@@ -1,10 +1,9 @@
 (ns calva-power-tools.tool.tools-deps
   (:require
    ["vscode" :as vscode]
-   [calva-power-tools.extension.calva :as calva]
+   [calva-power-tools.calva :as calva]
    [calva-power-tools.extension.db :as db]
    [calva-power-tools.extension.life-cycle-helpers :as lc-helpers]))
-
 
 (defn activate! []
   (calva/register-snippet! "deps.loadSelectedDependencies"

--- a/src/calva_power_tools/util.cljs
+++ b/src/calva_power_tools/util.cljs
@@ -10,3 +10,9 @@
                     {'" mvn-name " {:mvn/version \"" version "\"}})")
      :ns "user"
      :repl "clj"}))
+
+(defn tool-dependency-load-snippet [{:deps/keys [mvn-name]}]
+  {:snippet (str "((requiring-resolve 'clojure.repl.deps/add-lib)
+                    '" mvn-name ")")
+   :ns "user"
+   :repl "clj"})

--- a/src/calva_power_tools/util.cljs
+++ b/src/calva_power_tools/util.cljs
@@ -1,18 +1,53 @@
 (ns calva-power-tools.util
   (:require
-   ["vscode" :as vscode]))
+   ["vscode" :as vscode]
+   [promesa.core :as p]))
 
-(defn tool-dependency-load-version-snippet [{:config/keys [path]
-                                             :deps/keys [mvn-name]}]
-  (let [version (-> (vscode/workspace.getConfiguration "calva-power-tools")
-                    (.get path))]
-    {:snippet (str "((requiring-resolve 'clojure.repl.deps/add-libs)
-                    {'" mvn-name " {:mvn/version \"" version "\"}})")
-     :ns "user"
-     :repl "clj"}))
+(def ^:private ^js calva-ext (vscode/extensions.getExtension "betterthantomorrow.calva"))
 
-(defn tool-dependency-load-snippet [{:deps/keys [mvn-name]}]
-  {:snippet (str "((requiring-resolve 'clojure.repl.deps/add-lib)
-                    '" mvn-name ")")
-   :ns "user"
-   :repl "clj"})
+(def ^:private calva-api (-> calva-ext
+                             .-exports
+                             .-v1
+                             (js->clj :keywordize-keys true)))
+
+(def ^:private evaluateCode (get-in calva-api [:repl :evaluateCode]))
+
+(defn code-for-dependency-loading [{:deps/keys [mvn-name]}]
+  (str "(if-let [add-lib (resolve 'clojure.repl.deps/add-lib)]
+          (do (println \"Adding dependency: \"'" mvn-name ")
+              (add-lib '" mvn-name "))
+          (throw (ex-info (str \"FAILED adding dependency '" mvn-name ". clojure.repl.deps/add-lib was not found, Clojure 1.12 or higher is required\") {})))"))
+
+(defn load-dependency
+  "Load a dependency using Calva's REPL API directly.
+   Shows a progress dialog and handles errors with VS Code notifications.
+
+   Options map:
+     :deps/mvn-name - Maven artifact name (e.g. 'org.scicloj/clay')"
+  [{:deps/keys [mvn-name] :as m}]
+  (let [code (code-for-dependency-loading m)]
+    (-> (.withProgress vscode/window
+                       #js {:location vscode/ProgressLocation.Notification
+                            :title (str "Loading dependency: " mvn-name)
+                            :cancellable false}
+                       (fn [_progress _token]
+                         (p/create
+                          (fn [resolve reject]
+                            (-> (evaluateCode
+                                 "clj" code "user"
+                                 #js {:stdout (fn [output]
+                                                (js/console.log (str "Dependency loading stdout: " output)))
+                                      :stderr (fn [err]
+                                                (js/console.error (str "Dependency loading error: " err))
+                                                (when (not= err "")
+                                                  (reject err)))})
+                                (p/then (fn [result]
+                                          (resolve (.-result result))))
+                                (p/catch reject))))))
+        (p/then (fn [_]
+                  (vscode/window.showInformationMessage (str "Dependency " mvn-name " loaded.") "OK")))
+        (p/catch (fn [error-message]
+                   (vscode/window.showErrorMessage
+                    (str "Failed to load dependency " mvn-name ": " error-message)
+                    "OK")
+                   nil)))))

--- a/src/calva_power_tools/util.cljs
+++ b/src/calva_power_tools/util.cljs
@@ -1,0 +1,12 @@
+(ns calva-power-tools.util
+  (:require
+   ["vscode" :as vscode]))
+
+(defn tool-dependency-load-version-snippet [{:config/keys [path]
+                                             :deps/keys [mvn-name]}]
+  (let [version (-> (vscode/workspace.getConfiguration "calva-power-tools")
+                    (.get path))]
+    {:snippet (str "((requiring-resolve 'clojure.repl.deps/add-libs)
+                    {'" mvn-name " {:mvn/version \"" version "\"}})")
+     :ns "user"
+     :repl "clj"}))


### PR DESCRIPTION
## Description

Adding a command to load the Clay dependency. The dependency version is configurable from setting and currently defaults to `2-beta42`. We will need to keep it updated.

Now you can load the Clay dependency with a command and then use the Clay commands, in any project. My rationale is that it is better to have Clojure 1.12 configured in deps.edn than a bunch of development time dependencies that you need to keep updated.

- Fixes #18

## Checklist

- [x] I have read [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md)
- [x] There is an [issue](../issues) with a clear problem statement related to this change
- [x] I have added an entry to the **`[Unreleased]`** section of [CHANGELOG.md](../blob/master/CHANGELOG.md) linking to the issue(s) addressed
- [x] README/docs updated (or not relevant)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
