### PR TITLE
Change `cpt.showCommands` command's prefix `>CPT` to `>[CPT]` for more accurate filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva Power Tools
 
 ## [Unreleased]
 
+- [Change cpt.showCommands prefix](https://github.com/BetterThanTomorrow/calva-power-tools/issues/32)
+
 ## [v0.0.9] - 2025-05-16
 
 - [Add Dataspex tool](https://github.com/BetterThanTomorrow/calva-power-tools/issues/29)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ The default way of progress for a change to this project is:
 
 We prefer that each pull request is focused on one problem at the time. Even if sometimes related Issues can be addressed by the same changes.
 
-As part of your PR you update the `**[Unrelased]**` section of CHANGELOG.md, linking to the issue(s) addressed. WHen a new version of the extension is released a changelog entry will be created with everything that is in the unreleased section. The Changelog should read like a story of how the extension has evolved since its creation.
+As part of your PR you update the `**[Unreleased]**` section of CHANGELOG.md, linking to the issue(s) addressed. WHen a new version of the extension is released a changelog entry will be created with everything that is in the unreleased section. The Changelog should read like a story of how the extension has evolved since its creation.
 
 When you file a pull request some CI jobs will run:
 

--- a/src/calva_power_tools/extension.cljs
+++ b/src/calva_power_tools/extension.cljs
@@ -14,9 +14,9 @@
 
 (defn show-commands!
   ([]
-   (vscode/commands.executeCommand "workbench.action.quickOpen" ">CPT "))
+   (vscode/commands.executeCommand "workbench.action.quickOpen" ">[CPT] "))
   ([s]
-   (vscode/commands.executeCommand "workbench.action.quickOpen" (str ">CPT " s " "))))
+   (vscode/commands.executeCommand "workbench.action.quickOpen" (str ">[CPT] " s " "))))
 
 (defn ^:export activate [context]
   (js/console.time "activation")


### PR DESCRIPTION
<!-- Thanks for contributing!
     Please read CONTRIBUTING.md before filing a PR. -->

## Description

<!-- Describe your changes.
     Mention any decisions you took, and any alternatives you considered. -->

Change `cpt.showCommands` command's prefix `>CPT` to `>[CPT]` for more accurate filtering

<!-- Reference issues addressed by this PR.
     This is the WHY of the prosed changes. The problem(s) it solves. -->

- Fixes #32

## Checklist

- [x] I have read [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md)
- [x] There is an [issue](https://github.com/BetterThanTomorrow/calva-power-tools/issues/32) with a clear problem statement related to this change
- [x] I have added an entry to the **`[Unreleased]`** section of [CHANGELOG.md](../blob/master/CHANGELOG.md) linking to the issue(s) addressed
- [x] README/docs updated (or not relevant)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
