### PR TITLE
Add support for snitch's defmethod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to Calva Power Tools
 
 ## [Unreleased]
 
+- [Add support for defmethod* (Snitch)](https://github.com/BetterThanTomorrow/calva-power-tools/issues/31)
+
 ## [v0.0.10] - 2025-06-25
 
 - [Change `cpt.showCommands` command search `>CPT` to `>[CPT]` for more accurate filtering](https://github.com/BetterThanTomorrow/calva-power-tools/issues/32)

--- a/package.json
+++ b/package.json
@@ -154,22 +154,22 @@
       {
         "command": "cpt.snitch.instrumentTopLevelForm",
         "category": "[CPT] Snitch",
-        "title": "Instrument Top Level defn/let/fn"
+        "title": "Instrument Top Level defn/defmethod/let/fn"
       },
       {
         "command": "cpt.snitch.instrumentCurrentForm",
         "category": "[CPT] Snitch",
-        "title": "Instrument Current Form defn/let/fn"
+        "title": "Instrument Current Form defn/defmethod/let/fn"
       },
       {
         "command": "cpt.snitch.getSnitchedDefnResults",
         "category": "[CPT] Snitch",
-        "title": "Get Snitched defn Results"
+        "title": "Get Snitched defn/defmethod Results"
       },
       {
         "command": "cpt.snitch.reconstructLastDefnCallToClipboard",
         "category": "[CPT] Snitch",
-        "title": "Reconstruct Last defn Call to Clipboard"
+        "title": "Reconstruct Last defn/defmethod Call to Clipboard"
       },
       {
         "command": "cpt.performance.loadDecompilerDependency",

--- a/src/calva_power_tools/tool/snitch.cljs
+++ b/src/calva_power_tools/tool/snitch.cljs
@@ -11,13 +11,14 @@
 
 (defn- instrument-form [form]
   (let [snitched (.replace form
-                           #"\b(defn-?|fn|let)(?=\s)"
+                           #"\b(defn-?|defmethod|fn|let)(?=\s)"
                            (fn [s]
                              (case (string/trim s)
-                               "defn-" "defn*"
-                               "defn" "defn*"
-                               "let" "*let"
-                               "fn" "*fn"
+                               "defn-"     "defn*"
+                               "defn"      "defn*"
+                               "defmethod" "defmethod*"
+                               "let"       "*let"
+                               "fn"        "*fn"
                                s)))]
     (calva/execute-calva-command! "calva.runCustomREPLCommand"
                                   #js {:snippet snitched})))


### PR DESCRIPTION
## Description

This MR adds support for the defmethod* macro in all existing snitch commands, namely:
```json
{
  "command": "cpt.snitch.instrumentTopLevelForm",
  "category": "[CPT] Snitch",
  "title": "Instrument Top Level defn/defmethod/let/fn"
},
{
  "command": "cpt.snitch.instrumentCurrentForm",
  "category": "[CPT] Snitch",
  "title": "Instrument Current Form defn/defmethod/let/fn"
},
{
  "command": "cpt.snitch.getSnitchedDefnResults",
  "category": "[CPT] Snitch",
  "title": "Get Snitched defn/defmethod Results"
},
{
  "command": "cpt.snitch.reconstructLastDefnCallToClipboard",
  "category": "[CPT] Snitch",
  "title": "Reconstruct Last defn/defmethod Call to Clipboard"
},
```

Closes #31

Since there is no tests for this, I am attaching a video for both clj/cljs

https://github.com/user-attachments/assets/05550736-a4ed-4ebc-acb3-fcbc90bc24c6

https://github.com/user-attachments/assets/ba1f337d-7aa0-4a81-9b93-b8618fea3252

## Checklist

- [x] I have read [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md)
- [x] There is an [issue](../issues) with a clear problem statement related to this change
- [x] I have added an entry to the **`[Unreleased]`** section of [CHANGELOG.md](../blob/master/CHANGELOG.md) linking to the issue(s) addressed
- [x] README/docs updated (or not relevant)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
