### PR TITLE
Fix: No version found for org.clojars.abhinav/snitch

### DIFF
--- a/src/calva_power_tools/tool/snitch.cljs
+++ b/src/calva_power_tools/tool/snitch.cljs
@@ -46,7 +46,7 @@
                  (vscode/window.showInformationMessage "The snitched call to this function is saved to the clipboard."))))))
 
 (defn- load-dependency []
-  (-> (util/load-dependency {:deps/mvn-name "org.clojars.abhinav/snitch"})
+  (-> (util/load-dependency {:deps/mvn-name "org.clojars.abhinav/snitch" :deps/mvn-version "0.1.16"})
       (.then (fn [_]
                (calva/execute-calva-command!
                 "calva.runCustomREPLCommand"


### PR DESCRIPTION
**Problem:**
Users are encountering an "Execution error (ExceptionInfo)" with the message "Failed to load dependency org.clojars.abhinav/snitch: Execution error (ExceptionInfo) at clojure.repl.deps/add-lib (deps.clj:81). No version found for lib org.clojars.abhinav/snitch“.

**Solution:**
This commit explicitly adds a valid, stable version number (`"0.1.16"`) to the `org.clojars.abhinav/snitch` dependency definition.

By specifying the version, the dependency can be correctly resolved, downloaded, and loaded, resolving the reported execution error and allowing users to successfully utilize this library.

<!-- Thanks for contributing!
     Please read CONTRIBUTING.md before filing a PR. -->

## Description

<!-- Describe your changes.
     Mention any decisions you took, and any alternatives you considered. -->

...

<!-- Reference issues addressed by this PR.
     This is the WHY of the prosed changes. The problem(s) it solves. -->

- Fixes #...

## Checklist

- [ ] I have read [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md)
- [ ] There is an [issue](../issues) with a clear problem statement related to this change
- [ ] I have added an entry to the **`[Unreleased]`** section of [CHANGELOG.md](../blob/master/CHANGELOG.md) linking to the issue(s) addressed
- [ ] README/docs updated (or not relevant)
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
